### PR TITLE
Show message when no valid mask is configured

### DIFF
--- a/src/webfrontend/EditorTagfilterDefaults.coffee
+++ b/src/webfrontend/EditorTagfilterDefaults.coffee
@@ -272,7 +272,10 @@ class BaseConfigEditorTagfilterDefaults extends BaseConfigPlugin
 					type: CUI.Form
 					onRender: (form) =>
 						toggleUpdateOperation(form.getData(), form)
-					fields: [
+					fields: if mask_opts.length == 0 then [
+						type: CUI.Output
+						text: $$("editor.tagfilter.defaults.no-valid-mask")
+					] else [
 						type: CUI.Select
 						options: mask_opts
 						name: pname


### PR DESCRIPTION
...instead of dropdown with text "Missing: undefined"

I am using the locale key `editor.tagfilter.defaults.no-valid-mask`

Reasonable values could be

- `de-DE`: Keine gültigen Masken gefunden! Eine gültige Maske muss mindestens ein Feld vom Typ Text, Datum (aber kein Bereich!) oder Boolean anzeigen.
- `en-US`: No valid mask configurations found! A valid mask needs to show at least one field of either of these types: text, date (but not date range) or boolean.